### PR TITLE
Core component dialogs should use new FileUpload resourceType

### DIFF
--- a/image/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_dialog/.content.xml
+++ b/image/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_dialog/.content.xml
@@ -26,7 +26,7 @@
                         <items jcr:primaryType="nt:unstructured">
                             <file
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/foundation/form/fileupload"
+                                sling:resourceType="cq/gui/components/authoring/dialog/fileupload"
                                 autoStart="{Boolean}false"
                                 class="cq-droptarget"
                                 fieldLabel="Image asset"


### PR DESCRIPTION
Addresses https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/issues/6

A new resourceType has been introduced to present a Coral3-ready version of the dialog FileUpload. That is, in place of the previous Granite.FileUploadField clientlib that modified a granite/ui/components/foundation/form/fileupload. The new resourceType is cq/gui/components/authoring/dialog/fileupload