### PR TITLE
Disable maintaining image maps in the IPE

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_editConfig.xml
@@ -67,7 +67,7 @@
                 <fullscreen jcr:primaryType="nt:unstructured">
                     <toolbar
                         jcr:primaryType="nt:unstructured"
-                        left="[crop#launchwithratio,rotate#right,map#launch,flip#horizontal,flip#vertical,zoom#reset100,zoom#popupslider]"
+                        left="[crop#launchwithratio,rotate#right,flip#horizontal,flip#vertical,zoom#reset100,zoom#popupslider]"
                         right="[history#undo,history#redo,fullscreen#fullscreenexit]"/>
                     <replacementToolbars jcr:primaryType="nt:unstructured">
                         <crop


### PR DESCRIPTION
Image maps are currently not supported in the HTL markup and would
require some javascript to be usable in a responsive website, therefore
we should just disable them for now.

This fixes #35