### PR TITLE
Mobile Emulator Provider registration for page component

### DIFF
--- a/config/src/content/jcr_root/apps/core/wcm/config.author/com.day.cq.wcm.mobile.core.impl.MobileEmulatorProvider-core-components.config
+++ b/config/src/content/jcr_root/apps/core/wcm/config.author/com.day.cq.wcm.mobile.core.impl.MobileEmulatorProvider-core-components.config
@@ -1,0 +1,15 @@
+# Copyright 2017 Adobe Systems Incorporated
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+mobile.resourceTypes=["core/wcm/components/page/v1/page"]


### PR DESCRIPTION
pages with page components derived from `core/wcm/components/page/v1/page` do not show the "Emulator" button in the page editor, some other features do not work as well then.
registering the resource type as mobile emulator provider fixes the problem.