### PR TITLE
@trivial: added github templates for issues and PRs

### DIFF
--- a/.github/issue_template/bug_report.md
+++ b/.github/issue_template/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: 🐛 Bug Report
+about: It doesn't work for me. 🤔
+
+---
+<!-- 
+
+Before sending a bug report please check if the latest release (if you're not already using it) fixes your problem. Alternatively, you could
+install the latest snapshot version from the master branch.
+ -->
+
+## Bug Report
+
+**Current Behavior**
+A clear and concise description of the behavior and your setup; if applicable, proxy component pattern and component version.
+
+**Expected behavior/code**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+- AEM version and patch level (e.g. AEM 6.3 SP1 CFP2)
+- Core Components version (e.g. 2.0.4)
+- JRE version (e.g. `Java(TM) SE Runtime Environment (build 1.8.0_152-b16)`)
+
+**Possible Solution**
+<!--- Only if you have suggestions on a fix for the bug -->
+
+**Additional context / Screenshots**
+Add any other context about the problem here. If applicable, add screenshots to help explain.

--- a/.github/issue_template/feature_request.md
+++ b/.github/issue_template/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and I could even submit a PR 🤘🏼)!
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+
+**Are there alternatives?**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Documentation**
+If you can, explain how users will be able to use this and possibly write out a version of the docs.
+Maybe a screenshot or design?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+<!--
+Before making a PR please make sure to read our contributing guidelines
+https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md
+
+For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
+followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
+-->
+
+| Q                        | A <!--(Can use an emoji 👍) -->
+| ------------------------ | ---
+| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
+| Patch: Bug Fix?          |
+| Minor: New Feature?      |
+| Major: Breaking Change?  |
+| Tests Added + Pass?      | Yes
+| Documentation Provided   | Yes (code comments and or markdown)
+| Any Dependency Changes?  |
+| License                  | Apache License, Version 2.0
+
+<!-- Describe your changes below in as much detail as possible -->


### PR DESCRIPTION
The following templates should allow users to submit issues / PRs easier, by making sure that all required information is available from the beginning.