### PR TITLE
[Teaser] testHideElementsTeaser is using wrong selector for verification, timing issues (#191)

### DIFF
--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/sandbox/tests/test-cases/Teaser/v1/Teaser.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/sandbox/tests/test-cases/Teaser/v1/Teaser.js
@@ -210,12 +210,13 @@
                 data["sling:resourceType"] = "wcm/core/components/policies/mapping";
 
                 c.assignPolicy(policyName, data, done, policyAssignmentPath);
-            })
+            }, { after: 1000 })
+
             // open the dialog
             .execTestCase(c.tcOpenConfigureDialog("cmpPath"))
 
-            .assert.exist(selectors.component.title, false)
-            .assert.exist(selectors.component.description, false);
+            .assert.exist(selectors.editDialog.descriptionFromPage, false)
+            .assert.exist(selectors.editDialog.titleFromPage, false);
     };
 
     teaser.testLinksToElementsTeaser = function(tcExecuteBeforeTest, tcExecuteAfterTest, selectors, policyName, policyLocation, policyPath, policyAssignmentPath) {
@@ -240,7 +241,8 @@
                 data["sling:resourceType"] = "wcm/core/components/policies/mapping";
 
                 c.assignPolicy(policyName, data, done, policyAssignmentPath);
-            })
+            }, { after: 1000 })
+
             // open the dialog
             .execTestCase(c.tcOpenConfigureDialog("cmpPath"))
             .execFct(function(opts, done) {
@@ -287,7 +289,7 @@
                 data["sling:resourceType"] = "wcm/core/components/policies/mapping";
 
                 c.assignPolicy(policyName, data, done, policyAssignmentPath);
-            })
+            }, { after: 1000 })
 
             // open the dialog
             .execTestCase(c.tcOpenConfigureDialog("cmpPath"))


### PR DESCRIPTION
The Hobbes test teaser.testHideElementsTeaser is checking for the component output instead of edit dialog, so always passes.

Also the three teaser tests that create policies for their tests:

teaser.testHideElementsTeaser
teaser.testLinksToElementsTeaser
teaser.testDisableActionsTeaser

randomly fail on faster machines since opening the dialogs in next step can be faster then
the policy being applied beforehand, added a delay of 1 sec.
