### PR TITLE
[Image] Image map support for image component

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
@@ -26,7 +26,7 @@
     <a data-sly-unwrap="${!image.link}"
        class="cmp-image__link" href="${image.link}"
        data-cmp-hook-image="link">
-        <noscript data-sly-unwrap="${!image.lazyEnabled && image.widths.length <= 1}" data-cmp-hook-image="noscript">
+        <noscript data-sly-unwrap="${!image.lazyEnabled && image.widths.length <= 1 && !image.areas}" data-cmp-hook-image="noscript">
             <sly data-sly-test.usemap="${'{0}{1}' @ format=['#', resource.path]}"></sly>
             <img src="${image.src}" class="cmp-image__image" data-cmp-hook-image="image"
                  data-sly-attribute.usemap="${image.areas ? usemap : ''}"

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Image/v1/Image.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Image/v1/Image.js
@@ -33,7 +33,7 @@ window.CQ.CoreComponentsIT.Image.v1 = window.CQ.CoreComponentsIT.Image.v1 || {}
     /**
      * Before Test Case
      */
-    image.tcExecuteBeforeTest = function(imageRT, pageRT, jsComponentEnabled) {
+    image.tcExecuteBeforeTest = function(imageRT, pageRT) {
         return new h.TestCase("Setup Before Test")
             // common set up
             .execTestCase(c.tcExecuteBeforeTest)
@@ -50,32 +50,6 @@ window.CQ.CoreComponentsIT.Image.v1 = window.CQ.CoreComponentsIT.Image.v1 || {}
             // add the component, store component path in 'cmpPath'
             .execFct(function(opts, done) {
                 c.addComponent(h.param("compPath")(opts), h.param("testPagePath")(opts) + c.relParentCompPath, "cmpPath", done);
-            })
-
-            // create and assign a content policy to enable lazy loading; which initializes the frontend handling
-            .execFct(function(opts, done) {
-                if (jsComponentEnabled) {
-                    var data = {};
-                    data["jcr:title"] = "New Policy";
-                    data["sling:resourceType"] = "wcm/core/components/policy/policy";
-                    data["disableLazyLoading"] = "false";
-
-                    c.createPolicy("/image" + "/new_policy", data, "policyPath", done, c.policyPath);
-                } else {
-                    done();
-                }
-            })
-
-            .execFct(function(opts, done) {
-                if (jsComponentEnabled) {
-                    var data = {};
-                    data["cq:policy"] = "core-component/components" + "/image" + "/new_policy";
-                    data["sling:resourceType"] = "wcm/core/components/policies/mapping";
-
-                    c.assignPolicy("/image", data, done, c.policyAssignmentPath);
-                } else {
-                    done();
-                }
             })
 
             // open the new page in the editor

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Image/v2/Image.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/Image/v2/Image.js
@@ -144,11 +144,6 @@ window.CQ.CoreComponentsIT.Image.v2 = window.CQ.CoreComponentsIT.Image.v2 || {};
                 .navigateTo("/editor.html%testPagePath%.html"),
             execAfter: tcExecuteAfterTest }
         )
-            // verify the JS component is enabled
-            .asserts.isTrue(function() {
-                return h.find(selectors.elements.self + "[data-cmp-lazy]", "#ContentFrame").size() === 1;
-            })
-
             // verify the map area is available
             .asserts.isTrue(function() {
                 return h.find(selectors.elements.area, "#ContentFrame").size() === 1;

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Image/v2/Image.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Image/v2/Image.js
@@ -29,7 +29,7 @@
      * v2 specifics
      */
     var titleSelector = ".cmp-image__title";
-    var tcExecuteBeforeTest = imageV1.tcExecuteBeforeTest(c.rtImage_v2, "core/wcm/tests/components/test-page-v2", true);
+    var tcExecuteBeforeTest = imageV1.tcExecuteBeforeTest(c.rtImage_v2, "core/wcm/tests/components/test-page-v2");
     var tcExecuteAfterTest = imageV1.tcExecuteAfterTest();
 
     /**


### PR DESCRIPTION
- adds condition to noscript unwrap logic such that image map areas are responsively resized by the JS component even if there are no widths defined (as is the case for SVG images), and lazy loading is disabled (the default).
- updates ui-js test cases.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #35` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | N/A
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
