### PR TITLE
[Image] Adding support for schema.org/ImageObject to the Image component

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/image.html
@@ -22,13 +22,14 @@
      data-cmp-widths="${image.widths}"
      data-asset="${image.fileReference}"
      data-title="${image.title || image.alt}"
-     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}">
+     class="cmp-image${!wcmmode.disabled ? ' cq-dd-image' : ''}"
+     itemscope itemtype="http://schema.org/ImageObject">
     <a data-sly-unwrap="${!image.link}"
        class="cmp-image__link" href="${image.link}"
        data-cmp-hook-image="link">
         <noscript data-sly-unwrap="${!image.lazyEnabled && image.widths.length <= 1 && !image.areas}" data-cmp-hook-image="noscript">
             <sly data-sly-test.usemap="${'{0}{1}' @ format=['#', resource.path]}"></sly>
-            <img src="${image.src}" class="cmp-image__image" data-cmp-hook-image="image"
+            <img src="${image.src}" class="cmp-image__image" itemprop="contentUrl" data-cmp-hook-image="image"
                  data-sly-attribute.usemap="${image.areas ? usemap : ''}"
                  alt="${image.alt || true}" title="${image.displayPopupTitle && image.title}"/>
             <map data-sly-test="${image.areas}"
@@ -40,6 +41,7 @@
             </map>
         </noscript>
     </a>
-    <span class="cmp-image__title" data-sly-test="${!image.displayPopupTitle && image.title}">${image.title}</span>
+    <span class="cmp-image__title" itemprop="caption" data-sly-test="${!image.displayPopupTitle && image.title}">${image.title}</span>
+    <meta itemprop="caption" data-sly-test="${image.displayPopupTitle && image.title}">${image.title}</meta>
 </div>
 <sly data-sly-call="${templates.placeholder @ isEmpty = !image.src, classAppend = 'cmp-image cq-dd-image'}"></sly>


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Adds https://schema.org/ImageObject vocabulary for Image Component. Including:
* `contentUrl`
* `caption` (If the visible caption span is disabled, we provide a meta equivalent) 

we may also consider adding an additional meta tag for `description` derived from the alt text. Any other ideas welcome, there are for example properties for `dateCreated`, `dateModified`, `datePublished` and other metadata.

<img width="610" alt="screen shot 2018-06-27 at 14 14 37" src="https://user-images.githubusercontent.com/25616660/41973178-833731be-7a14-11e8-8754-289f1bc92f0b.png">

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #221` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
