### PR TITLE
[Navigation] Adding support for schema.org/SiteNavigationElement to t…

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/navigation/v1/navigation/navigation.html
@@ -14,6 +14,7 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <nav class="cmp-navigation"
+     itemscope itemtype="http://schema.org/SiteNavigationElement"
      data-sly-use.template="core/wcm/components/commons/v1/templates.html"
      data-sly-use.navigation="com.adobe.cq.wcm.core.components.models.Navigation"
      data-sly-test.hasContent="${navigation.items.size > 0}"


### PR DESCRIPTION
…he Navigation component

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

Adds https://schema.org/SiteNavigationElement to the Navigation Component.

As far as understand, the itemprop="name" and itemprop="url" attributes shouldn't be applied to individual list items and their anchors, rather to a name or url representing the whole navigation, which we don't have.

If we were to add these to the items, although valid, it would lead to an unstructured list of unrelated names and urls in the schema.

So, I think here it is enough to simply identify the wrapping nav element as `SiteNavigationElement`. 

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #222` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->