### PR TITLE
Issue #231 [Title] inplaceEditing doesn't work properly for H5 and H6 title types

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v1/title/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v1/title/_cq_editConfig.xml
@@ -7,6 +7,6 @@
         editorType="title">
         <config
             jcr:primaryType="nt:unstructured"
-            titleTag="[h1,h2,h3,h4]"/>
+            titleTag="[h1,h2,h3,h4,h5,h6]"/>
     </cq:inplaceEditing>
 </jcr:root>

--- a/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/title/v2/title/_cq_editConfig.xml
@@ -7,6 +7,6 @@
         editorType="title">
         <config
             jcr:primaryType="nt:unstructured"
-            titleTag="[h1,h2,h3,h4]"/>
+            titleTag="[h1,h2,h3,h4,h5,h6]"/>
     </cq:inplaceEditing>
 </jcr:root>


### PR DESCRIPTION
| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #231
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  |NO
| License                  | Apache License, Version 2.0

Fixes the inlineEditing issue for H5 and H6 styles for title component
