### PR TITLE
add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "aem-core-wcm-components",
+    "version": "2.1.0",
+    "description": "Adobe Experience Manager Core WCM Components",
+    "license": "Apache-2.0",
+    "private": false,
+    "homepage": "https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components"
+    }
+}


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #122  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | Add package.json 
| Major: Breaking Change?  |
| Tests Added + Pass?      | N/A
| Documentation Provided   | N/A
| Any Dependency Changes?  | N/A
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Hi, 

We're prototyping a few components outside of AEM in a static front-end build that have dependencies on AEM clientlibs, so it's useful for us to be able to add this repo as an [NPM](https://www.npmjs.com/) dependency. NPM requires a package.json file in order to import the dependency. While this repo isn't published as an NPM module, we can consume it as a GIT repo (https://docs.npmjs.com/files/package.json#git-urls-as-dependencies). 

I tested out using my fork to import the following files into our project and it worked fine:
- content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/polyfills.js
- content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js

I've followed the format of https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/content/package.json (ideally we'd pull in just this directory but NPM doesn't support that for GIT modules).

Cheers
Jon