### PR TITLE
[Image] allow to configure jpeg quality

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImpl.java
@@ -123,6 +123,7 @@ public class ImageImpl implements Image {
     protected String baseResourcePath;
     protected String templateRelativePath;
     protected boolean disableLazyLoading;
+    protected int jpegQuality;
 
     public ImageImpl() {
         selector = AdaptiveImageServlet.DEFAULT_SELECTOR;
@@ -186,6 +187,7 @@ public class ImageImpl implements Image {
                 extension = DEFAULT_EXTENSION;
             }
             disableLazyLoading = currentStyle.get(PN_DESIGN_LAZY_LOADING_ENABLED, false);
+            jpegQuality = currentStyle.get(PN_DESIGN_JPEG_QUALITY, AdaptiveImageServlet.DEFAULT_JPEG_QUALITY);
             int index = 0;
             Template template = currentPage.getTemplate();
             if (template != null && resource.getPath().startsWith(template.getPath())) {
@@ -202,7 +204,7 @@ public class ImageImpl implements Image {
                 smartSizes = new int[supportedRenditionWidths.size()];
                 for (Integer width : supportedRenditionWidths) {
                     smartImages[index] = baseResourcePath + DOT +
-                        selector + DOT + width + DOT + extension +
+                        selector + DOT + jpegQuality + DOT + width + DOT + extension +
                         (inTemplate ? Text.escapePath(templateRelativePath) : "") +
                         (lastModifiedDate > 0 ? "/" + lastModifiedDate + DOT + extension : "");
                     smartSizes[index] = width;
@@ -214,7 +216,7 @@ public class ImageImpl implements Image {
             }
             src = baseResourcePath + DOT + selector + DOT;
             if (smartSizes.length == 1) {
-                src += smartSizes[0] + DOT + extension;
+                src += jpegQuality + DOT + smartSizes[0] + DOT + extension;
             } else {
                 src += extension;
             }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/internal/models/v2/ImageImpl.java
@@ -95,7 +95,12 @@ public class ImageImpl extends com.adobe.cq.wcm.core.components.internal.models.
         if (hasContent) {
             disableLazyLoading = currentStyle.get(PN_DESIGN_LAZY_LOADING_ENABLED, true);
 
-            srcUriTemplate = baseResourcePath + DOT + selector +
+            String staticSelectors = selector;
+            if (smartSizes.length > 0) {
+                // only include the quality selector in the URL, if there are sizes configured
+                staticSelectors += DOT + jpegQuality;
+            } 
+            srcUriTemplate = baseResourcePath + DOT + staticSelectors +
                     SRC_URI_TEMPLATE_WIDTH_VAR + DOT + extension +
                     (inTemplate ? templateRelativePath : "") + (lastModifiedDate > 0 ? "/" + lastModifiedDate + DOT + extension : "");
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/Image.java
@@ -39,6 +39,13 @@ public interface Image extends ComponentExporter {
     String PN_DESIGN_ALLOWED_RENDITION_WIDTHS = "allowedRenditionWidths";
 
     /**
+     * Name of the configuration policy property that will store the image quality for an image.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     */
+    String PN_DESIGN_JPEG_QUALITY = "jpegQuality";
+
+    /**
      * Name of the configuration policy property that will indicate if lazy loading should be disabled.
      *
      * @since com.adobe.cq.wcm.core.components.models 11.0.0

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.4.0")
+@Version("12.5.0")
 package com.adobe.cq.wcm.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/internal/models/v1/ImageImplTest.java
@@ -92,7 +92,7 @@ public class ImageImplTest extends AbstractImageTest {
         assertNull("Did not expect a file reference.", image.getFileReference());
         assertFalse("Image should not display a caption popup.", image.displayPopupTitle());
         assertEquals(IMAGE_LINK, image.getLink());
-        assertEquals(CONTEXT_PATH + escapedResourcePath + "." + selector + ".600.png/1490005239000.png", image.getSrc());
+        assertEquals(CONTEXT_PATH + escapedResourcePath + "." + selector + ".82.600.png/1490005239000.png", image.getSrc());
         String expectedJson = "{\"smartImages\":[\"/core/content/test/_jcr_content/root/image3." + selector + ".600.png/1490005239000.png\"]," +
                 "\"smartSizes\":[600]," +
                 "\"lazyEnabled\":false}";

--- a/bundles/core/src/test/resources/image/exporter-image3.json
+++ b/bundles/core/src/test/resources/image/exporter-image3.json
@@ -1,7 +1,7 @@
 {
     "alt": "Adobe Logo",
     "title": "Adobe Logo",
-    "src": "/core/content/test/_jcr_content/root/image3.img.600.png/1490005239000.png",
+    "src": "/core/content/test/_jcr_content/root/image3.img.82.600.png/1490005239000.png",
     "link": "https://www.adobe.com",
     ":type": "core/wcm/components/image/v1/image"
 }

--- a/bundles/core/src/test/resources/image/v2/exporter-image0.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image0.json
@@ -8,7 +8,7 @@
     ],
     "areas": [],
     "lazyEnabled"           : false,
-    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image0.coreimg{.width}.png/1490005239000.png",
+    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image0.coreimg.82{.width}.png/1490005239000.png",
     "title"                 : "Adobe Systems Logo and Wordmark",
     "alt"                   : "Adobe Systems Logo and Wordmark in PNG format",
     "link"                  : "/core/content/test-image.html",

--- a/bundles/core/src/test/resources/image/v2/exporter-image18.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image18.json
@@ -11,7 +11,7 @@
     ],
     "areas": [],
     "lazyEnabled"           : true,
-    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image18.coreimg{.width}.png/1490005239000.png",
+    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image18.coreimg.82{.width}.png/1490005239000.png",
     "src"                   : "/core/content/test/_jcr_content/root/image18.coreimg.png/1490005239000.png",
     ":type"                 : "core/wcm/components/image/v2/image"
 }

--- a/bundles/core/src/test/resources/image/v2/exporter-image3-with-policy-delegate.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image3-with-policy-delegate.json
@@ -4,10 +4,10 @@
     ],
     "areas": [],
     "lazyEnabled"           : false,
-    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image3.coreimg{.width}.png?contentPolicyDelegatePath=/content/test/jcr:content/root/image0",
+    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image3.coreimg.82{.width}.png?contentPolicyDelegatePath=/content/test/jcr:content/root/image0",
     "title"                 : "Adobe Logo",
     "alt"                   : "Adobe Logo",
     "link"                  : "https://www.adobe.com",
-    "src"                   : "/core/content/test/_jcr_content/root/image3.coreimg.600.png?contentPolicyDelegatePath=/content/test/jcr:content/root/image0",
+    "src"                   : "/core/content/test/_jcr_content/root/image3.coreimg.82.600.png?contentPolicyDelegatePath=/content/test/jcr:content/root/image0",
     ":type"                 : "core/wcm/components/image/v2/image"
 }

--- a/bundles/core/src/test/resources/image/v2/exporter-image3.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image3.json
@@ -4,10 +4,10 @@
     ],
     "areas": [],
     "lazyEnabled"           : false,
-    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image3.coreimg{.width}.png",
+    "srcUriTemplate"        : "/core/content/test/_jcr_content/root/image3.coreimg.82{.width}.png",
     "title"                 : "Adobe Logo",
     "alt"                   : "Adobe Logo",
     "link"                  : "https://www.adobe.com",
-    "src"                   : "/core/content/test/_jcr_content/root/image3.coreimg.600.png",
+    "src"                   : "/core/content/test/_jcr_content/root/image3.coreimg.82.600.png",
     ":type"                 : "core/wcm/components/image/v2/image"
 }

--- a/bundles/core/src/test/resources/image/v2/exporter-image_template.json
+++ b/bundles/core/src/test/resources/image/v2/exporter-image_template.json
@@ -1,5 +1,5 @@
 {
-    "srcUriTemplate": "/core/content/test.coreimg{.width}.png/structure/jcr:content/root/image_template/1490005239000.png",
+    "srcUriTemplate": "/core/content/test.coreimg.82{.width}.png/structure/jcr:content/root/image_template/1490005239000.png",
     "widths" : [
         600,
         700,

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v1/image/_cq_design_dialog/.content.xml
@@ -38,6 +38,17 @@
                                             name="./allowedRenditionWidths"
                                             required="{Boolean}true"/>
                                     </allowedWidths>
+                                    <jpegQuality 
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                        fieldDescription="The quality factor (in percentage from 0 and 100) for transformed (e.g. scaled or cropped) JPEG images."
+                                        fieldLabel="JPEG Quality"
+                                        name="./jpegQuality"
+                                        typeHint="Long"
+                                        required="{Boolean}true"
+                                        min="{Long}0"
+                                        max="{Long}100"
+                                        defaultValue="{Long}82" />
                                     <disableLazyLoading
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_design_dialog/.content.xml
@@ -100,6 +100,17 @@
                                             name="./allowedRenditionWidths"
                                             required="{Boolean}true"/>
                                     </widths>
+                                    <jpegQuality 
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                        fieldDescription="The quality factor (in percentage from 0 and 100) for transformed (e.g. scaled or cropped) JPEG images."
+                                        fieldLabel="JPEG Quality"
+                                        name="./jpegQuality"
+                                        typeHint="Long"
+                                        required="{Boolean}true"
+                                        min="{Long}0"
+                                        max="{Long}100"
+                                        defaultValue="{Long}82" />
                                 </items>
                             </content>
                         </items>


### PR DESCRIPTION
This closes #254

| Q                        | A 
| ------------------------ | ---
| Fixed Issues?            | Fixes #254
| Patch: Bug Fix?          |  No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

This adds an optional additional selector for the image servlet specifying the image quality (only considered for transformed JPEG images currently). The quality is reflected in the image url to bust the caches in case the image quality has been changed. The image quality is configurable via the content policies.
