### PR TITLE
[Fixes #279] Edit action to open to the chosen variation of the content fragment

### DIFF
--- a/extension/contentfragment/content/src/content/jcr_root/apps/core/wcm/extension/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js
+++ b/extension/contentfragment/content/src/content/jcr_root/apps/core/wcm/extension/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js
@@ -38,8 +38,8 @@
             var fragmentPath = $(editable.dom).find("." + CLASS_CONTENTFRAGMENT).attr(ATTRIBUTE_PATH);
             if (fragmentPath) {
                 var fragmentEditUrl = EDITOR_URL + fragmentPath;
-                var fragment = Granite.author.CFM.Fragments.adaptToFragment(editable.dom);
-                if (fragment && typeof fragment.variation !== 'undefined') {
+                var fragment = ns.CFM.Fragments.adaptToFragment(editable.dom);
+                if (fragment && typeof fragment.variation !== 'undefined' && fragment.variation !== 'master') {
                     fragmentEditUrl = fragmentEditUrl + "?variation=" + fragment.variation;
                 }
                 // open the editor in a new window

--- a/extension/contentfragment/content/src/content/jcr_root/apps/core/wcm/extension/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js
+++ b/extension/contentfragment/content/src/content/jcr_root/apps/core/wcm/extension/components/contentfragment/v1/contentfragment/clientlibs/editor/authoring/js/editAction.js
@@ -37,8 +37,13 @@
             // get the path of the content fragment
             var fragmentPath = $(editable.dom).find("." + CLASS_CONTENTFRAGMENT).attr(ATTRIBUTE_PATH);
             if (fragmentPath) {
+                var fragmentEditUrl = EDITOR_URL + fragmentPath;
+                var fragment = Granite.author.CFM.Fragments.adaptToFragment(editable.dom);
+                if (fragment && typeof fragment.variation !== 'undefined') {
+                    fragmentEditUrl = fragmentEditUrl + "?variation=" + fragment.variation;
+                }
                 // open the editor in a new window
-                window.open(Granite.HTTP.externalize(EDITOR_URL + fragmentPath));
+                window.open(Granite.HTTP.externalize(fragmentEditUrl));
             }
         }
 


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #279 
| Patch: Bug Fix?          | Bug Fix
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | No
| Documentation Provided   | No
| Any Dependency Changes?  | No
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
Updated the edit action for content fragment components to open the selected content fragment variation by populating the `variation` query parameter with the `variationName` value for the CF Editor URL
