### PR TITLE
[Carousel] Navigation fails on a Carousel item selection from the Content Tree

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js.txt
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js.txt
@@ -21,3 +21,4 @@ PanelContainer.js
 panelContainerRegistry.js
 panelContainerUtils.js
 panelContainerActions.js
+contentTree.js

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/PanelContainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/PanelContainer.js
@@ -20,6 +20,7 @@
     var GET_DATA_SUFFIX = ".model.json";
     var POST_SUFFIX = ".childreneditor.html";
     var MESSAGE_ID = "cmp.panelcontainer";
+    var NAVIGATE_DELAY = 200;
 
     /**
      * @typedef {Object} PanelContainerConfig Represents a Panel Container configuration object
@@ -62,6 +63,7 @@
          * [Content Frame]{@link Granite.author.ContentFrame} and lets the related UI widget handle the operation.
          *
          * @param {Number} index Index of the panel to navigate to
+         * @fires CQ.CoreComponents.PanelContainer#cmp-panelcontainer-navigated
          */
         navigate: function(index) {
             if (this._config.panelContainerType) {
@@ -69,12 +71,22 @@
                 // for correct forwarding of operations in the content frame message subscription.
                 this._config.el.dataset["cmpPanelcontainerId"] = this._config.path;
 
-                Granite.author.ContentFrame.postMessage(MESSAGE_ID, {
+                var data = {
                     id: this._config.path,
                     type: this._config.panelContainerType.name,
                     operation: "navigate",
                     index: index
-                });
+                };
+
+                Granite.author.ContentFrame.postMessage(MESSAGE_ID, data);
+
+                setTimeout(function() {
+                    channel.trigger({
+                        type: "cmp-panelcontainer-navigated",
+                        id: data.id,
+                        index: data.index
+                    });
+                }, NAVIGATE_DELAY);
             }
         },
 
@@ -164,6 +176,15 @@
                 }
             });
         }
+
+        /**
+         * Triggered when the Panel Container has navigated.
+         *
+         * @event CQ.CoreComponents.PanelContainer#cmp-panelcontainer-navigated
+         * @param {Object} event Event object.
+         * @param {String} event.id The Panel Container ID (path)
+         * @param {Number} event.index Index of the navigated to Panel Container item
+         */
     });
 
 }(jQuery, Granite.author, jQuery(document), this));

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/PanelContainer.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/PanelContainer.js
@@ -183,7 +183,7 @@
          * @event CQ.CoreComponents.PanelContainer#cmp-panelcontainer-navigated
          * @param {Object} event Event object.
          * @param {String} event.id The Panel Container ID (path)
-         * @param {Number} event.index Index of the navigated to Panel Container item
+         * @param {Number} event.index Index of the Panel Container item that is navigated to
          */
     });
 

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/contentTree.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/contentTree.js
@@ -1,0 +1,141 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2018 Adobe Systems Incorporated
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+/* global CQ */
+(function($, ns, channel, window, undefined) {
+    "use strict";
+
+    var selectors = {
+        contentTree: ".editor-ContentTree coral-tree"
+    };
+
+    /**
+     * Handling to ensure the {@link Granite.author.ui.ContentTree} selection logic functions
+     * with Panel Containers.
+     */
+
+    /**
+     * Sync Panel Container child {@link Granite.author.Editable} overlay disabled states on navigate,
+     * to prevent the Content Tree selection logic from triggering a click on
+     * overlays that aren't yet visible in the Content Frame.
+     *
+     * @param {jQuery.Event} event The panel navigation event Object
+     */
+    channel.on("cmp-panelcontainer-navigated", function(event) {
+        var editables = ns.editables.find(event.id);
+        if (editables.length) {
+            updatePanelContainerOverlayState(editables[0]);
+        }
+    });
+
+    /**
+     * Ensure Panel Container child Editable overlay disabled states are updated
+     * when the Editor is loaded.
+     *
+     * @param {jQuery.Event} event The editor loaded event Object
+     */
+    channel.on("cq-editor-loaded", function(event) {
+        var editables = ns.editables;
+
+        for (var i = 0; i < editables.length; i++) {
+            var editable = editables[i];
+
+            if (CQ.CoreComponents.panelcontainer.utils.isPanelContainer(editable)) {
+                updatePanelContainerOverlayState(editable);
+            }
+        }
+    });
+
+    /**
+     * Bind content tree change events to replace the default selection logic of the
+     * {@link Granite.author.ui.ContentTree} for Panel Container items.
+     *
+     * @param {jQuery.Event} event The sidepanel tab switched event Object
+     */
+    channel.on("cq-sidepanel-tab-switched", function(event) {
+        Coral.commons.nextFrame(function() {
+            var $contentTree = $(selectors.contentTree);
+
+            if ($contentTree.length) {
+                var contentTree = $contentTree[0];
+
+                contentTree.off("coral-tree:change.panelcontainer").on("coral-tree:change.panelcontainer", function() {
+                    var selectedItem = contentTree.selectedItem;
+
+                    if (selectedItem) {
+                        var editable = ns.editables.find(selectedItem.value)[0];
+                        var editableParent = editable.getParent();
+                        var panelContainer;
+                        var panelContainerType = CQ.CoreComponents.panelcontainer.utils.getPanelContainerType(editableParent);
+                        if (panelContainerType) {
+                            panelContainer = new CQ.CoreComponents.PanelContainer({
+                                path: editableParent.path,
+                                panelContainerType: panelContainerType,
+                                el: CQ.CoreComponents.panelcontainer.utils.getPanelContainerHTMLElement(editableParent)
+                            });
+
+                            var index = Array.prototype.indexOf.call(selectedItem.parentElement.children, selectedItem);
+
+                            channel.one("cmp-panelcontainer-navigated", function() {
+                                editable.overlay.dom.focus();
+                                ns.selection.deselectAll();
+                                ns.selection.deactivateCurrent();
+                                ns.selection.select(editable);
+                                ns.selection.activate(editable);
+
+                                var active = ns.selection.getCurrentActive();
+
+                                // If an editable has received the focus
+                                if (active) {
+                                    channel.trigger($.Event("cq-interaction-focus", {
+                                        editable: active
+                                    }));
+                                }
+                            });
+
+                            panelContainer.navigate(index);
+                        }
+                    }
+                });
+            }
+        });
+    });
+
+    /**
+     * Toggles Panel Container items' overlay disabled state based on the current active index
+     *
+     * @param {Granite.author.Editable} editable The Panel Container {@link Granite.author.Editable}
+     */
+    function updatePanelContainerOverlayState(editable) {
+        var panelContainerType = CQ.CoreComponents.panelcontainer.utils.getPanelContainerType(editable);
+        var panelContainer;
+
+        if (panelContainerType) {
+            panelContainer = new CQ.CoreComponents.PanelContainer({
+                path: editable.path,
+                panelContainerType: panelContainerType,
+                el: CQ.CoreComponents.panelcontainer.utils.getPanelContainerHTMLElement(editable)
+            });
+        }
+
+        var activeIndex = panelContainer.getActiveIndex();
+        var items = CQ.CoreComponents.panelcontainer.utils.getPanelContainerItems(editable);
+
+        for (var i = 0; i < items.length; i++) {
+            items[i].overlay.setDisabled((activeIndex !== i));
+        }
+    }
+
+}(jQuery, Granite.author, jQuery(document), this));

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/contentTree.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/commons/ui/clientlibs/panelcontainer/js/contentTree.js
@@ -27,9 +27,10 @@
      */
 
     /**
-     * Sync Panel Container child {@link Granite.author.Editable} overlay disabled states on navigate,
-     * to prevent the Content Tree selection logic from triggering a click on
-     * overlays that aren't yet visible in the Content Frame.
+     * Disable/enable {@link Granite.author.ui.Overlay}s for Panel Container items on navigate.
+     * The overlays of the non-active Panel Container items are disabled.
+     * Necessary for preventing the default Content Tree selection logic from triggering a click on
+     * overlays that aren't visible in the Content Frame.
      *
      * @param {jQuery.Event} event The panel navigation event Object
      */


### PR DESCRIPTION
- introduces `cmp-panelcontainer-navigated` event.
- disables panel container item editable overlays that aren’t the active one.
- adds content tree listeners to navigate to and select panels on change.

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #285 <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | 
| Documentation Provided   |  (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
