### PR TITLE
Disable Lazy load of Image if the image has lazyLoad attribute

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -200,7 +200,7 @@
             var imageElement = temporaryDocument.querySelector(selectors.image);
             // Remove src if the src image referred is not a temp image file
             var srcAttribute = imageElement.getAttribute("src");
-            if (srcAttribute && srcAttribute.indexOf(TEMP_DESIGN_PATH) == -1) {
+            if (srcAttribute && srcAttribute.indexOf(TEMP_DESIGN_PATH) === -1) {
                 imageElement.removeAttribute("src");
             }
             that._elements.container.insertBefore(imageElement, that._elements.noscript);

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -20,7 +20,7 @@
     var IS = "image";
 
     var EMPTY_PIXEL = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
-    var TEMP_DESIGN_PATH = "/var/designs/";
+    var LAZY_LOAD_DISABLED_ATTR = "disablelazyload";
     var LAZY_THRESHOLD = 0;
     var SRC_URI_TEMPLATE_WIDTH_VAR = "{.width}";
 
@@ -143,9 +143,8 @@
             var hasWidths = that._properties.widths && that._properties.widths.length > 0;
             var replacement = hasWidths ? "." + getOptimalWidth() : "";
             var url = that._properties.src.replace(SRC_URI_TEMPLATE_WIDTH_VAR, replacement);
-
-            var srcAttribute = that._elements.image.getAttribute("src");
-            if (!srcAttribute && srcAttribute !== url) {
+            let disableLazyLoad = that._elements.image.getAttribute(LAZY_LOAD_DISABLED_ATTR);
+            if (disableLazyLoad !== "true" && that._elements.image.getAttribute("src") !== url) {
                 that._elements.image.setAttribute("src", url);
                 if (!hasWidths) {
                     window.removeEventListener("scroll", that.update);
@@ -198,9 +197,8 @@
             // temporary document avoids requesting the image before removing its src
             var temporaryDocument = parser.parseFromString(markup, "text/html");
             var imageElement = temporaryDocument.querySelector(selectors.image);
-            // Remove src if the src image referred is not a temp image file
-            var srcAttribute = imageElement.getAttribute("src");
-            if (srcAttribute && srcAttribute.indexOf(TEMP_DESIGN_PATH) === -1) {
+            let disableLazyLoad = imageElement.getAttribute(LAZY_LOAD_DISABLED_ATTR);
+            if (disableLazyLoad !== "true") {
                 imageElement.removeAttribute("src");
             }
             that._elements.container.insertBefore(imageElement, that._elements.noscript);

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -20,6 +20,7 @@
     var IS = "image";
 
     var EMPTY_PIXEL = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7";
+    var TEMP_DESIGN_PATH = "/var/designs/";
     var LAZY_THRESHOLD = 0;
     var SRC_URI_TEMPLATE_WIDTH_VAR = "{.width}";
 
@@ -143,7 +144,8 @@
             var replacement = hasWidths ? "." + getOptimalWidth() : "";
             var url = that._properties.src.replace(SRC_URI_TEMPLATE_WIDTH_VAR, replacement);
 
-            if (that._elements.image.getAttribute("src") !== url) {
+            var srcAttribute = that._elements.image.getAttribute("src");
+            if (!srcAttribute && srcAttribute !== url) {
                 that._elements.image.setAttribute("src", url);
                 if (!hasWidths) {
                     window.removeEventListener("scroll", that.update);
@@ -196,6 +198,11 @@
             // temporary document avoids requesting the image before removing its src
             var temporaryDocument = parser.parseFromString(markup, "text/html");
             var imageElement = temporaryDocument.querySelector(selectors.image);
+            // Remove src if the src image referred is not a temp image file
+            var srcAttribute = imageElement.getAttribute("src");
+            if (srcAttribute && srcAttribute.indexOf(TEMP_DESIGN_PATH) == -1) {
+                imageElement.removeAttribute("src");
+            }
             imageElement.removeAttribute("src");
             that._elements.container.insertBefore(imageElement, that._elements.noscript);
 

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -203,7 +203,6 @@
             if (srcAttribute && srcAttribute.indexOf(TEMP_DESIGN_PATH) == -1) {
                 imageElement.removeAttribute("src");
             }
-            imageElement.removeAttribute("src");
             that._elements.container.insertBefore(imageElement, that._elements.noscript);
 
             var mapElement = temporaryDocument.querySelector(selectors.map);


### PR DESCRIPTION
 - Export a site containing image component using .export.zip method

 - Extract the downloaded zip and open the .html file in your browser

 - Observe that the images are not displayed in the site even though they are present in the exported zip folder

 - Site Image links are written in a temporary path '/var/designs/' and written in the site before exporting the site and have a lazy Load disable attribute set in them

 - Page Exporter exports the images of the site in /var/designs/ directory in the zip

 - Image js again rewrites the links and thus breaking the img element upon page load

 - Don't rewrite the links upon page load if the image doesn't allow lazy load

 - CQ-4241179

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | CQ-4241179
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      |
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
