### PR TITLE
Raise dependency of resourceresolver-mock to 1.1.22

### DIFF
--- a/testing/junit/core/pom.xml
+++ b/testing/junit/core/pom.xml
@@ -165,7 +165,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.testing.resourceresolver-mock</artifactId>
-            <version>1.1.20</version>
+            <version>1.1.22</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
We raise the dependency of
'org.apache.sling:org.apache.sling.testing.resourceresolver-mock' to
version 1.1.22 to be in sync with
'org.apache.sling:org.apache.sling.testing.sling-mock.core' which
requires it. This module will otherwise override the version with an
incompatible one.

NOTE: I ran into this issue because I wanted to add a test in module `com.adobe.cq:core.wcm.components.extension.contentfragment.bundle`utilizing Sling mocks. Above library pulls in an incompatible version of `org.apache.sling.testing.resourceresolver.MockResourceResolverFactoryOptions`resulting in 
```bash
java.lang.RuntimeException: Unable to initialize RESOURCERESOLVER_MOCK resource resolver factory: org.apache.sling.testing.resourceresolver.MockResourceResolverFactoryOptions.setMangleNamespacePrefixes(Z)Lorg/apache/sling/testing/resourceresolver/MockResourceResolverFactoryOptions;

	at org.apache.sling.testing.mock.sling.context.ContextResourceResolverFactory.get(ContextResourceResolverFactory.java:68)
	at org.apache.sling.testing.mock.sling.context.SlingContextImpl.newResourceResolverFactory(SlingContextImpl.java:136)
	at org.apache.sling.testing.mock.sling.context.SlingContextImpl.resourceResolverFactory(SlingContextImpl.java:141)
	at org.apache.sling.testing.mock.sling.context.SlingContextImpl.resourceResolver(SlingContextImpl.java:261)
	at org.apache.sling.testing.mock.sling.context.SlingContextImpl.load(SlingContextImpl.java:328)
	at org.apache.sling.testing.mock.sling.context.SlingContextImpl.load(SlingContextImpl.java:318)
```

As follow up, one would have to raise the test dependency of `core.wcm.components.junit.core` after a release.