### PR TITLE
Issue #296 [UI Tests] Tests fail for Form Options and Teaser

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/_cq_dialog/.content.xml
@@ -316,14 +316,22 @@
                                                             emptyText="Link"
                                                             name="link"
                                                             required="{Boolean}true"
-                                                            rootPath="/content"/>
+                                                            rootPath="/content">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cmp-teaser-v1-dialog-edit-hook="actionLink"/>
+                                                        </link>
                                                         <text
                                                             granite:class="cmp-teaser__editor-actionField"
                                                             jcr:primaryType="nt:unstructured"
                                                             sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
                                                             emptyText="Text"
                                                             name="text"
-                                                            required="{Boolean}true"/>
+                                                            required="{Boolean}true">
+                                                            <granite:data
+                                                                jcr:primaryType="nt:unstructured"
+                                                                cmp-teaser-v1-dialog-edit-hook="actionTitle"/>
+                                                        </text>
                                                     </items>
                                                 </field>
                                             </actions>

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/js/teaser.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/clientlibs/editor/js/teaser.js
@@ -88,7 +88,7 @@
                     var newMultifieldItem = new Coral.Multifield.Item();
                     actionsMultifield.items.add(newMultifieldItem);
                     Coral.commons.ready(newMultifieldItem, function(element) {
-                        var linkField = $(element).find('foundation-autocomplete[name="link"]');
+                        var linkField = $(element).find("[data-cmp-teaser-v1-dialog-edit-hook='actionLink']");
                         if (linkField) {
                             linkField.val(linkURL);
                             linkField.trigger("change");
@@ -107,8 +107,8 @@
 
     function toggleActionItems(actionsMultifield, disabled) {
         actionsMultifield.find("coral-multifield-item").each(function(ix, item) {
-            var linkField = $(item).find("foundation-autocomplete[name='link']").adaptTo("foundation-field");
-            var textField = $(item).find("input[name='text']").adaptTo("foundation-field");
+            var linkField = $(item).find("[data-cmp-teaser-v1-dialog-edit-hook='actionLink']").adaptTo("foundation-field");
+            var textField = $(item).find("[data-cmp-teaser-v1-dialog-edit-hook='actionTitle']").adaptTo("foundation-field");
             if (disabled && linkField.getValue() === "" && textField.getValue() === "") {
                 actionsMultifield[0].items.remove(item);
             }
@@ -120,7 +120,7 @@
     function retrievePageInfo(dialogContent) {
         var url;
         if (actionsEnabled) {
-            url = dialogContent.find('.cmp-teaser__editor-multifield_actions [name="link"]').val();
+            url = dialogContent.find('.cmp-teaser__editor-multifield_actions [data-cmp-teaser-v1-dialog-edit-hook="actionLink"]').val();
         } else {
             url = linkURL;
         }
@@ -144,7 +144,7 @@
     function updateText(target) {
         var url = target.val();
         if (url && url.startsWith("/")) {
-            var textField = target.parents("coral-multifield-item").find('[name="text"]');
+            var textField = target.parents("coral-multifield-item").find('[data-cmp-teaser-v1-dialog-edit-hook="actionTitle"]');
             if (textField && !textField.val()) {
                 $.ajax({
                     url: url + "/_jcr_content.json"

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/FormOptions/v1/FormOptions.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-cases/FormOptions/v1/FormOptions.js
@@ -99,9 +99,9 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
         // press the Add button
         .click("button :contains('Add')")
         // set the value
-        .fillInput("input[name='./value']", value)
+        .fillInput("input[name$='value']", value)
         // set the text
-        .fillInput("input[name='./text']", text)
+        .fillInput("input[name$='text']", text)
     ;
 
     /**
@@ -336,7 +336,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Active' option
-            .click("input[type='checkbox'][name='./selected']")
+            .click("input[type='checkbox'][name$='selected']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is active
@@ -359,7 +359,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Active' option
-            .click("input[type='radio'][name='./selected']")
+            .click("input[type='radio'][name$='selected']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is active
@@ -382,7 +382,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Active' option
-            .click("input[type='radio'][name='./selected']")
+            .click("input[type='radio'][name$='selected']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is active
@@ -405,7 +405,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Active' option
-            .click("input[type='checkbox'][name='./selected']")
+            .click("input[type='checkbox'][name$='selected']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is active
@@ -428,7 +428,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Disabled' option
-            .click("input[type='checkbox'][name='./disabled']")
+            .click("input[type='checkbox'][name$='disabled']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is disabled
@@ -451,7 +451,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Disabled' option
-            .click("input[type='checkbox'][name='./disabled']")
+            .click("input[type='checkbox'][name$='disabled']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is disabled
@@ -474,7 +474,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Disabled' option
-            .click("input[type='checkbox'][name='./disabled']")
+            .click("input[type='checkbox'][name$='disabled']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is disabled
@@ -497,7 +497,7 @@ window.CQ.CoreComponentsIT.FormOptions.v1 = window.CQ.CoreComponentsIT.FormOptio
             // add one option
             .execTestCase(formOptions.addOption)
             // check the 'Disabled' option
-            .click("input[type='checkbox'][name='./disabled']")
+            .click("input[type='checkbox'][name$='disabled']")
             // close the edit dialog
             .execTestCase(c.tcSaveConfigureDialog)
             // check if the option is disabled

--- a/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Teaser/v1/Teaser.js
+++ b/testing/it/ui-js/src/content/jcr_root/apps/core/wcm/tests/test-suites/Teaser/v1/Teaser.js
@@ -39,8 +39,8 @@
             descriptionFromPage: 'input[name="./descriptionFromPage"]',
             description: 'input[name="./jcr:description"]',
             actionsEnabled: 'coral-checkbox[name="./actionsEnabled"]',
-            actionLinkURL: 'foundation-autocomplete[name="link"]',
-            actionText: 'input[name="text"]'
+            actionLinkURL: '[data-cmp-teaser-v1-dialog-edit-hook="actionLink"]',
+            actionText: '[data-cmp-teaser-v1-dialog-edit-hook="actionTitle"]'
         }
     };
 


### PR DESCRIPTION
Fixed Issues? #296 

- The granite UI multifield component is going to change behavior in next release which will be backported to 6.3. and 6.4 as well.
- The change involves the value of the name attribute of all elements inside a multifield item. It its going to be fully expanded upon dialog rendering. E.g. instead of:

```name="text"```

it will be rendered as:

```name ="./items/item0/text"```

- A number of FormOptions UI tests will fail as they use the```name``` attribute and value to target elements.
- The teaser will no longer work properly since the teaser's editor clientlib also use the ```name``` attribute and value as selectors in the code. This also causes tests to fail.
- The fix for FormOption tests is to change the selector to search for ending substring.
- The fix for the Teaser clientlib is to add ```data-``` attributes to be able to target the element independently of the underlying UI element.

As a follow up task you wo should decide on a common pattern to identify UI elements for testing and clientlibs that is independent of the underlying implementation by using either ```data-``` attributes or classes.
