### PR TITLE
[DevTools] Add aemfed script for live reload following local content changes

### DIFF
--- a/content/package.json
+++ b/content/package.json
@@ -10,6 +10,7 @@
         "url": "https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components"
     },
     "scripts": {
+        "aemfed": "aemfed -t \"http://admin:admin@localhost:4502\" -e \"**/*___jb_(old|tmp)___\" -w \"src/content/jcr_root/\"",
         "eslint": "eslint .",
         "eslint:fix": "eslint . --fix",
         "lint": "npm-run-all --parallel eslint stylelint",
@@ -17,6 +18,7 @@
         "stylelint:fix": "stylelint '**/*.css' '**/*.less' --fix"
     },
     "devDependencies": {
+        "aemfed": "^0.0.5",
         "eslint": "^4.19.1",
         "npm-run-all": "^4.1.2",
         "stylelint": "^9.2.0",

--- a/content/package.json
+++ b/content/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components"
     },
     "scripts": {
-        "aemfed": "aemfed -t \"http://admin:admin@localhost:4502\" -e \"**/*___jb_(old|tmp)___\" -w \"src/content/jcr_root/\"",
+        "aemfed": "aemfed -e \"**/*___jb_(old|tmp)___\" -w \"src/content/jcr_root/\"",
         "eslint": "eslint .",
         "eslint:fix": "eslint . --fix",
         "lint": "npm-run-all --parallel eslint stylelint",


### PR DESCRIPTION
Adds an npm script to allow running aemfed, for live reload of content / clientlibs during development. See: https://github.com/abmaonline/aemfed.

Example commands (run from /content folder):
* Run: `npm run aemfed`
* Run for non-default target: `npm run aemfed -- -t "http://admin:admin@localhost:8080"`

fixes #300 