### PR TITLE
[Carousel][Image] Images don't get the proper size/width when they are selected into the view

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -156,7 +156,12 @@
         }
 
         function getOptimalWidth() {
-            var containerWidth = that._elements.self.clientWidth;
+            var container = that._elements.self;
+            var containerWidth = container.clientWidth;
+            while (containerWidth === 0 && container.parentNode) {
+                container = container.parentNode;
+                containerWidth = container.clientWidth;
+            }
             var optimalWidth = containerWidth * devicePixelRatio;
             var len = that._properties.widths.length;
             var key = 0;


### PR DESCRIPTION
* Getting the width from the first visible parent in case the image is hidden
* Fixes #305 
