### PR TITLE
[Carousel] Transition between slides with delay

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImpl.java
@@ -21,8 +21,10 @@ import java.util.List;
 import javax.annotation.PostConstruct;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Exporter;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,6 +34,7 @@ import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.sandbox.models.Carousel;
 import com.day.cq.wcm.api.components.Component;
 import com.day.cq.wcm.api.components.ComponentManager;
+import com.day.cq.wcm.api.designer.Style;
 
 @Model(adaptables = SlingHttpServletRequest.class, adapters = {Carousel.class, ComponentExporter.class}, resourceType = CarouselImpl.RESOURCE_TYPE)
 @Exporter(name = ExporterConstants.SLING_MODEL_EXPORTER_NAME, extensions = ExporterConstants.SLING_MODEL_EXTENSION)
@@ -39,5 +42,32 @@ public class CarouselImpl extends AbstractContainerImpl implements Carousel {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CarouselImpl.class);
 
-    public final static String RESOURCE_TYPE = "core/wcm/sandbox/components/carousel/v1/carousel";
+    public static final String RESOURCE_TYPE = "core/wcm/sandbox/components/carousel/v1/carousel";
+    protected static final int DEFAULT_DELAY = 5; // seconds
+
+    @ScriptVariable
+    protected Style currentStyle;
+
+    @ScriptVariable
+    protected ValueMap properties;
+
+    protected boolean auto;
+    protected Long delay;
+
+    @PostConstruct
+    protected void initModel() {
+        auto = properties.get(PN_AUTO, currentStyle.get(PN_AUTO, false));
+        delay = (long)1000 * properties.get(PN_DELAY, currentStyle.get(PN_DELAY, DEFAULT_DELAY));
+    }
+
+    @Override
+    public boolean getAuto() {
+        return auto;
+    }
+
+    @Override
+    public Long getDelay() {
+        return delay;
+    }
+
 }

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImpl.java
@@ -43,7 +43,7 @@ public class CarouselImpl extends AbstractContainerImpl implements Carousel {
     private static final Logger LOGGER = LoggerFactory.getLogger(CarouselImpl.class);
 
     public static final String RESOURCE_TYPE = "core/wcm/sandbox/components/carousel/v1/carousel";
-    protected static final int DEFAULT_DELAY = 5; // seconds
+    protected static final Long DEFAULT_DELAY = 5000L; // milliseconds
 
     @ScriptVariable
     protected Style currentStyle;
@@ -57,7 +57,7 @@ public class CarouselImpl extends AbstractContainerImpl implements Carousel {
     @PostConstruct
     protected void initModel() {
         autoplay = properties.get(PN_AUTOPLAY, currentStyle.get(PN_AUTOPLAY, false));
-        delay = (long)1000 * properties.get(PN_DELAY, currentStyle.get(PN_DELAY, DEFAULT_DELAY));
+        delay = properties.get(PN_DELAY, currentStyle.get(PN_DELAY, DEFAULT_DELAY));
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImpl.java
@@ -51,18 +51,18 @@ public class CarouselImpl extends AbstractContainerImpl implements Carousel {
     @ScriptVariable
     protected ValueMap properties;
 
-    protected boolean auto;
+    protected boolean autoplay;
     protected Long delay;
 
     @PostConstruct
     protected void initModel() {
-        auto = properties.get(PN_AUTO, currentStyle.get(PN_AUTO, false));
+        autoplay = properties.get(PN_AUTOPLAY, currentStyle.get(PN_AUTOPLAY, false));
         delay = (long)1000 * properties.get(PN_DELAY, currentStyle.get(PN_DELAY, DEFAULT_DELAY));
     }
 
     @Override
-    public boolean getAuto() {
-        return auto;
+    public boolean getAutoplay() {
+        return autoplay;
     }
 
     @Override

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
@@ -28,14 +28,14 @@ public interface Carousel extends Container {
     /**
      * Name of the resource property that indicates whether to automatically transition between slides, or not.
      *
-     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     * @since com.adobe.cq.wcm.core.components.sandbox.models 1.0.0
      */
     String PN_AUTOPLAY = "autoplay";
 
     /**
      * Name of the resource property that indicates the delay (in milliseconds) when automatically transitioning between slides.
      *
-     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     * @since com.adobe.cq.wcm.core.components.sandbox.models 1.0.0
      */
     String PN_DELAY = "delay";
 
@@ -43,7 +43,7 @@ public interface Carousel extends Container {
      * Indicates whether the carousel should automatically transition between slides or not.
      *
      * @return {@code true} if the carousel should automatically transition slides; {@code false} otherwise
-     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     * @since com.adobe.cq.wcm.core.components.sandbox.models 1.0.0
      */
     default boolean getAutoplay() {
         throw new UnsupportedOperationException();
@@ -53,7 +53,7 @@ public interface Carousel extends Container {
      * Returns the delay (in milliseconds) when automatically transitioning between slides.
      *
      * @return the delay (in milliseconds) when automatically transitioning between slides
-     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     * @since com.adobe.cq.wcm.core.components.sandbox.models 1.0.0
      */
     default Long getDelay() {
         throw new UnsupportedOperationException();

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
@@ -33,7 +33,7 @@ public interface Carousel extends Container {
     String PN_AUTOPLAY = "autoplay";
 
     /**
-     * Name of the resource property that indicates the delay (in seconds) when automatically transitioning between slides.
+     * Name of the resource property that indicates the delay (in milliseconds) when automatically transitioning between slides.
      *
      * @since com.adobe.cq.wcm.core.components.models 12.5.0
      */

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
@@ -30,7 +30,7 @@ public interface Carousel extends Container {
      *
      * @since com.adobe.cq.wcm.core.components.models 12.5.0
      */
-    String PN_AUTO = "auto";
+    String PN_AUTOPLAY = "autoplay";
 
     /**
      * Name of the resource property that indicates the delay (in seconds) when automatically transitioning between slides.
@@ -45,7 +45,7 @@ public interface Carousel extends Container {
      * @return {@code true} if the carousel should automatically transition slides; {@code false} otherwise
      * @since com.adobe.cq.wcm.core.components.models 12.5.0
      */
-    default boolean getAuto() {
+    default boolean getAutoplay() {
         throw new UnsupportedOperationException();
     }
 

--- a/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
+++ b/bundles/core/src/main/java/com/adobe/cq/wcm/core/components/sandbox/models/Carousel.java
@@ -24,4 +24,39 @@ import org.osgi.annotation.versioning.ConsumerType;
  */
 @ConsumerType
 public interface Carousel extends Container {
+
+    /**
+     * Name of the resource property that indicates whether to automatically transition between slides, or not.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     */
+    String PN_AUTO = "auto";
+
+    /**
+     * Name of the resource property that indicates the delay (in seconds) when automatically transitioning between slides.
+     *
+     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     */
+    String PN_DELAY = "delay";
+
+    /**
+     * Indicates whether the carousel should automatically transition between slides or not.
+     *
+     * @return {@code true} if the carousel should automatically transition slides; {@code false} otherwise
+     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     */
+    default boolean getAuto() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Returns the delay (in milliseconds) when automatically transitioning between slides.
+     *
+     * @return the delay (in milliseconds) when automatically transitioning between slides
+     * @since com.adobe.cq.wcm.core.components.models 12.5.0
+     */
+    default Long getDelay() {
+        throw new UnsupportedOperationException();
+    }
+
 }

--- a/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/wcm/core/components/sandbox/internal/models/CarouselImplTest.java
@@ -21,7 +21,6 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.testing.mock.sling.servlet.MockSlingHttpServletRequest;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -30,9 +29,14 @@ import com.adobe.cq.sightly.WCMBindings;
 import com.adobe.cq.wcm.core.components.context.CoreComponentTestContext;
 import com.adobe.cq.wcm.core.components.models.ListItem;
 import com.adobe.cq.wcm.core.components.sandbox.models.Carousel;
+import com.day.cq.wcm.api.designer.Style;
 import io.wcm.testing.mock.aem.junit.AemContext;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CarouselImplTest {
 
@@ -56,7 +60,7 @@ public class CarouselImplTest {
     public void testEmptyCarousel() {
         Carousel carousel = new CarouselImpl();
         List<ListItem> items = carousel.getItems();
-        Assert.assertTrue("", items == null || items.size() == 0);
+        assertTrue("", items == null || items.size() == 0);
     }
 
     @Test
@@ -68,6 +72,13 @@ public class CarouselImplTest {
         };
         verifyCarouselItems(expectedItems, carousel.getItems());
         //Utils.testJSONExport(carousel, Utils.getTestExporterJSONPath(TEST_BASE, "carousel1"));
+    }
+
+    @Test
+    public void testCarouselProperties() {
+        Carousel carousel = getCarouselUnderTest(CAROUSEL_1);
+        assertTrue(carousel.getAutoplay());
+        assertEquals(new Long(7000), carousel.getDelay());
     }
 
     private Carousel getCarouselUnderTest(String resourcePath) {
@@ -83,6 +94,11 @@ public class CarouselImplTest {
         slingBindings.put(SlingBindings.RESOURCE, resource);
         slingBindings.put(WCMBindings.PROPERTIES, resource.adaptTo(ValueMap.class));
         slingBindings.put(WCMBindings.PAGE_MANAGER, AEM_CONTEXT.pageManager());
+        Style style = mock(Style.class);
+        when(style.get(any(), any(Object.class))).thenAnswer(
+            invocation -> invocation.getArguments()[1]
+        );
+        slingBindings.put(WCMBindings.CURRENT_STYLE, style);
         request.setAttribute(SlingBindings.class.getName(), slingBindings);
         return request.adaptTo(Carousel.class);
     }

--- a/bundles/core/src/test/resources/carousel/test-content.json
+++ b/bundles/core/src/test/resources/carousel/test-content.json
@@ -16,6 +16,8 @@
                         "jcr:primaryType"   : "nt:unstructured",
                         "jcr:title"         : "Carousel 1",
                         "sling:resourceType": "core/wcm/sandbox/components/carousel/v1/carousel",
+                        "autoplay"          : "true",
+                        "delay"             : "7",
                         "item_1": {
                             "jcr:primaryType"   : "nt:unstructured",
                             "jcr:title"         : "Teaser 1",

--- a/bundles/core/src/test/resources/carousel/test-content.json
+++ b/bundles/core/src/test/resources/carousel/test-content.json
@@ -17,7 +17,7 @@
                         "jcr:title"         : "Carousel 1",
                         "sling:resourceType": "core/wcm/sandbox/components/carousel/v1/carousel",
                         "autoplay"          : "true",
-                        "delay"             : "7",
+                        "delay"             : "7000",
                         "item_1": {
                             "jcr:primaryType"   : "nt:unstructured",
                             "jcr:title"         : "Teaser 1",

--- a/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/clientlibs/site/js/text.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/form/text/v2/text/clientlibs/site/js/text.js
@@ -27,11 +27,15 @@
     var properties = {
         /**
          * A validation message to display if there is a type mismatch between the user input and expected input.
+         *
+         * @type {String}
          */
         constraintMessage: {
         },
         /**
          * A validation message to display if no input is supplied, but input is expected for the field.
+         *
+         * @type {String}
          */
         requiredMessage: {
         }

--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/clientlibs/site/js/image.js
@@ -42,11 +42,14 @@
         /**
          * An array of alternative image widths (in pixels).
          * Used to replace a {.width} variable in the src property with an optimal width if a URI template is provided.
+         *
+         * @memberof Image
+         * @type {Number[]}
+         * @default []
          */
         "widths": {
             "default": [],
             "transform": function(value) {
-                // number[]
                 var widths = [];
                 value.split(",").forEach(function(item) {
                     item = parseFloat(item);
@@ -59,11 +62,14 @@
         },
         /**
          * Indicates whether the image should be rendered lazily.
+         *
+         * @memberof Image
+         * @type {Boolean}
+         * @default false
          */
         "lazy": {
             "default": false,
             "transform": function(value) {
-                // boolean
                 return !(value === null || typeof value === "undefined");
             }
         },
@@ -73,6 +79,9 @@
          * Can be a simple image source, or a URI template representation that
          * can be variable expanded - useful for building an image configuration with an alternative width.
          * e.g. '/path/image.coreimg{.width}.jpeg/1506620954214.jpeg'
+         *
+         * @memberof Image
+         * @type {String}
          */
         "src": {
         }

--- a/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/clientlibs/site/js/search.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/search/v1/search/clientlibs/site/js/search.js
@@ -43,22 +43,28 @@
     var properties = {
         /**
          * The minimum required length of the search term before results are fetched.
+         *
+         * @memberof Search
+         * @type {Number}
+         * @default 3
          */
         minLength: {
             "default": 3,
             transform: function(value) {
-                // number
                 value = parseFloat(value);
                 return isNaN(value) ? null : value;
             }
         },
         /**
          * The maximal number of results fetched by a search request.
+         *
+         * @memberof Search
+         * @type {Number}
+         * @default 10
          */
         resultsSize: {
             "default": 10,
             transform: function(value) {
-                // number
                 value = parseFloat(value);
                 return isNaN(value) ? null : value;
             }

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/README.md
@@ -43,7 +43,7 @@ BLOCK cmp-carousel
     ELEMENT cmp-carousel__content
     ELEMENT cmp-carousel__item
     ELEMENT cmp-carousel__action
-        MOD cmp-carousel__action--prev
+        MOD cmp-carousel__action--previous
         MOD cmp-carousel__action--next
     ELEMENT cmp-carousel__action-icon
     ELEMENT cmp-carousel__action-text
@@ -58,8 +58,9 @@ A hook attribute from the following should be added to the corresponding element
 
 ```
 data-cmp-hook-carousel="item"
-data-cmp-hook-carousel="prev"
+data-cmp-hook-carousel="previous"
 data-cmp-hook-carousel="next"
+data-cmp-hook-carousel="indicators"
 data-cmp-hook-carousel="indicator"
 ```
 

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/README.md
@@ -54,6 +54,11 @@ BLOCK cmp-carousel
 ## JavaScript Data Attribute Bindings
 Apply a `data-cmp-is="carousel"` attribute to the wrapper block to enable initialization of the JavaScript component.
 
+The following attributes can be added to the same element to provide options:
+
+1. `data-cmp-autoplay` - if the attribute is present, indicates that the carousel should automatically transition between slides.
+2. `data-cmp-delay` - the delay (in milliseconds) when automatically transitioning between slides.
+
 A hook attribute from the following should be added to the corresponding element so that the JavaScript is able to target it:
 
 ```

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -53,7 +53,7 @@
                                 min="0"
                                 max="600000"
                                 name="./delay"
-                                step="200"
+                                step="100"
                                 value="5000"/>
                         </items>
                     </properties>

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -31,6 +31,32 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 maximized="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
+                    <properties
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Properties"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <auto
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                fieldDescription="If checked, automatically transition between carousel slides."
+                                name="./auto"
+                                text="Automatically transition slides"
+                                uncheckedValue="false"
+                                value="{Boolean}true"/>
+                            <delay
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                fieldDescription="The delay (in seconds) before automatically transitioning to the next slide."
+                                fieldLabel="Transition Delay (seconds)"
+                                min="0"
+                                max="600"
+                                name="./delay"
+                                step="0.1"
+                                value="5"/>
+                        </items>
+                    </properties>
                     <allowedcomponents
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Allowed Components"

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -44,7 +44,7 @@
                                 name="./autoplay"
                                 text="Automatically transition slides"
                                 uncheckedValue="false"
-                                value="{Boolean}true"/>
+                                value="true"/>
                             <delay
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -48,13 +48,13 @@
                             <delay
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                fieldDescription="The delay (in seconds) before automatically transitioning to the next slide."
-                                fieldLabel="Transition Delay (seconds)"
+                                fieldDescription="The delay (in milliseconds) before automatically transitioning to the next slide."
+                                fieldLabel="Transition Delay (milliseconds)"
                                 min="0"
-                                max="600"
+                                max="600000"
                                 name="./delay"
-                                step="0.1"
-                                value="5"/>
+                                step="200"
+                                value="5000"/>
                         </items>
                     </properties>
                     <allowedcomponents

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_design_dialog/.content.xml
@@ -37,11 +37,11 @@
                         sling:resourceType="granite/ui/components/coral/foundation/container"
                         margin="{Boolean}true">
                         <items jcr:primaryType="nt:unstructured">
-                            <auto
+                            <autoplay
                                 jcr:primaryType="nt:unstructured"
                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
                                 fieldDescription="If checked, automatically transition between carousel slides."
-                                name="./auto"
+                                name="./autoplay"
                                 text="Automatically transition slides"
                                 uncheckedValue="false"
                                 value="{Boolean}true"/>

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -32,6 +32,30 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 maximized="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
+                    <items
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Items"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <slides
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="core/wcm/sandbox/commons/ui/components/childreneditor"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </items>
                     <properties
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Properties"
@@ -59,43 +83,19 @@
                                             <delay
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
-                                                fieldDescription="The delay (in seconds) before automatically transitioning to the next slide."
-                                                fieldLabel="Transition Delay (seconds)"
+                                                fieldDescription="The delay (in milliseconds) before automatically transitioning to the next slide."
+                                                fieldLabel="Transition Delay (milliseconds)"
                                                 min="0"
-                                                max="600"
+                                                max="600000"
                                                 name="./delay"
-                                                step="0.1"
-                                                value="${not empty cqDesign.delay ? cqDesign.delay : 5}"/>
+                                                step="200"
+                                                value="${not empty cqDesign.delay ? cqDesign.delay : 5000}"/>
                                         </items>
                                     </column>
                                 </items>
                             </columns>
                         </items>
                     </properties>
-                    <slides
-                        jcr:primaryType="nt:unstructured"
-                        jcr:title="Slides"
-                        sling:resourceType="granite/ui/components/coral/foundation/container"
-                        margin="{Boolean}true">
-                        <items jcr:primaryType="nt:unstructured">
-                            <columns
-                                jcr:primaryType="nt:unstructured"
-                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
-                                margin="{Boolean}true">
-                                <items jcr:primaryType="nt:unstructured">
-                                    <column
-                                        jcr:primaryType="nt:unstructured"
-                                        sling:resourceType="granite/ui/components/coral/foundation/container">
-                                        <items jcr:primaryType="nt:unstructured">
-                                            <slides
-                                                jcr:primaryType="nt:unstructured"
-                                                sling:resourceType="core/wcm/sandbox/commons/ui/components/childreneditor"/>
-                                        </items>
-                                    </column>
-                                </items>
-                            </columns>
-                        </items>
-                    </slides>
                 </items>
             </tabs>
         </items>

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -88,7 +88,7 @@
                                                 min="0"
                                                 max="600000"
                                                 name="./delay"
-                                                step="200"
+                                                step="100"
                                                 value="${not empty cqDesign.delay ? cqDesign.delay : 5000}"/>
                                         </items>
                                     </column>

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -32,6 +32,46 @@
                 sling:resourceType="granite/ui/components/coral/foundation/tabs"
                 maximized="{Boolean}true">
                 <items jcr:primaryType="nt:unstructured">
+                    <properties
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="Properties"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column
+                                        jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <auto
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                checked="${not empty cqDesign.auto ? cqDesign.auto : false}"
+                                                fieldDescription="If checked, automatically transition between slides."
+                                                name="./auto"
+                                                text="Automatically transition slides"
+                                                uncheckedValue="false"
+                                                value="{Boolean}true"/>
+                                            <delay
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                fieldDescription="The delay (in seconds) before automatically transitioning to the next slide."
+                                                fieldLabel="Transition Delay (seconds)"
+                                                min="0"
+                                                max="600"
+                                                name="./delay"
+                                                step="0.1"
+                                                value="${not empty cqDesign.delay ? cqDesign.delay : 5}"/>
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </properties>
                     <slides
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Slides"

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/_cq_dialog/.content.xml
@@ -47,15 +47,15 @@
                                         jcr:primaryType="nt:unstructured"
                                         sling:resourceType="granite/ui/components/coral/foundation/container">
                                         <items jcr:primaryType="nt:unstructured">
-                                            <auto
+                                            <autoplay
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
-                                                checked="${not empty cqDesign.auto ? cqDesign.auto : false}"
+                                                checked="${not empty cqDesign.autoplay ? cqDesign.autoplay : false}"
                                                 fieldDescription="If checked, automatically transition between slides."
-                                                name="./auto"
+                                                name="./autoplay"
                                                 text="Automatically transition slides"
                                                 uncheckedValue="false"
-                                                value="{Boolean}true"/>
+                                                value="true"/>
                                             <delay
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
@@ -16,14 +16,16 @@
 <div data-sly-use.carousel="com.adobe.cq.wcm.core.components.sandbox.models.Carousel"
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      class="cmp-carousel"
-     data-cmp-is="carousel">
+     data-cmp-is="carousel"
+     data-cmp-auto="${Carousel.auto}"
+     data-cmp-delay="${Carousel.delay}">
     <div class="cmp-carousel__content" data-sly-test="${carousel.items && carousel.items.size > 0}" >
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.path @ decorationTagName='div'}"
              role="tabpanel"
              class="cmp-carousel__item"
              data-cmp-hook-carousel="item"></div>
-        <button role="button" class="cmp-carousel__action cmp-carousel__action--prev" data-cmp-hook-carousel="prev">
+        <button role="button" class="cmp-carousel__action cmp-carousel__action--previous" data-cmp-hook-carousel="previous">
             <span class="cmp-carousel__action-icon"></span>
             <span class="cmp-carousel__action-text">${'Previous' @ i18n}</span>
         </button>
@@ -31,7 +33,7 @@
             <span class="cmp-carousel__action-icon"></span>
             <span class="cmp-carousel__action-text">${'Next' @ i18n}</span>
         </button>
-        <ol role="tablist" class="cmp-carousel__indicators">
+        <ol role="tablist" class="cmp-carousel__indicators" data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"
                 role="tab"
                 class="cmp-carousel__indicator"

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
@@ -17,8 +17,8 @@
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      class="cmp-carousel"
      data-cmp-is="carousel"
-     data-cmp-auto="${Carousel.auto}"
-     data-cmp-delay="${Carousel.delay}">
+     data-cmp-autoplay="${(wcmmode.edit || wcmmode.preview) ? '' : carousel.autoplay}"
+     data-cmp-delay="${carousel.delay}">
     <div class="cmp-carousel__content" data-sly-test="${carousel.items && carousel.items.size > 0}" >
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.path @ decorationTagName='div'}"

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/css/carousel.less
@@ -61,7 +61,7 @@
     background-size: 100% 100%;
 }
 
-.cmp-carousel__action--prev {
+.cmp-carousel__action--previous {
     left: 0;
 
     .cmp-carousel__action-icon {

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -41,7 +41,7 @@
          * @type {Boolean}
          * @default false
          */
-        "auto": {
+        "autoplay": {
             "default": false,
             "transform": function(value) {
                 return !(value === null || typeof value === "undefined");
@@ -52,7 +52,7 @@
          *
          * @memberof Carousel
          * @type {Number}
-         * @default 3000
+         * @default 5000
          */
         "delay": {
             "default": 5000,
@@ -102,7 +102,7 @@
             if (that._elements.item) {
                 refreshActive();
                 bindEvents();
-                resetAutoInterval();
+                resetAutoplayInterval();
             }
 
             if (Granite && Granite.author && Granite.author.MessageChannel) {
@@ -216,11 +216,11 @@
             }
 
             that._elements.self.addEventListener("mouseenter", function() {
-                clearAutoInterval();
+                clearAutoplayInterval();
             });
 
             that._elements.self.addEventListener("mouseleave", function() {
-                resetAutoInterval();
+                resetAutoplayInterval();
             });
         }
 
@@ -340,9 +340,9 @@
             that._active = index;
             refreshActive();
 
-            // reset the auto transition interval following navigation, if not already hovering the carousel
+            // reset the autoplay transition interval following navigation, if not already hovering the carousel
             if (that._elements.self.parentElement.querySelector(":hover") !== that._elements.self) {
-                resetAutoInterval();
+                resetAutoplayInterval();
             }
         }
 
@@ -362,12 +362,12 @@
          *
          * @private
          */
-        function resetAutoInterval() {
-            if (!that._properties.auto) {
+        function resetAutoplayInterval() {
+            if (!that._properties.autoplay) {
                 return;
             }
-            clearAutoInterval();
-            that._autoInterval = window.setInterval(function() {
+            clearAutoplayInterval();
+            that._autoplayIntervalId = window.setInterval(function() {
                 var indicators = that._elements["indicators"];
                 if (indicators !== document.activeElement && indicators.contains(document.activeElement)) {
                     // if an indicator has focus, ensure we switch focus following navigation
@@ -383,9 +383,9 @@
          *
          * @private
          */
-        function clearAutoInterval() {
-            window.clearInterval(that._autoInterval);
-            that._autoInterval = null;
+        function clearAutoplayInterval() {
+            window.clearInterval(that._autoplayIntervalId);
+            that._autoplayIntervalId = null;
         }
     }
 

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -33,13 +33,47 @@
         self: "[data-" +  NS + '-is="' + IS + '"]'
     };
 
+    var properties = {
+        /**
+         * Determines whether the Carousel will automatically transition between slides
+         *
+         * @memberof Carousel
+         * @type {Boolean}
+         * @default false
+         */
+        "auto": {
+            "default": false,
+            "transform": function(value) {
+                return !(value === null || typeof value === "undefined");
+            }
+        },
+        /**
+         * Duration (in milliseconds) before automatically transitioning to the next slide
+         *
+         * @memberof Carousel
+         * @type {Number}
+         * @default 3000
+         */
+        "delay": {
+            "default": 5000,
+            "transform": function(value) {
+                value = parseFloat(value);
+                return !isNaN(value) ? value : null;
+            }
+        }
+    };
+
     /**
+     * Carousel Configuration
+     *
      * @typedef {Object} CarouselConfig Represents a Carousel configuration
      * @property {HTMLElement} element The HTMLElement representing the Carousel
      * @property {Object} options The Carousel options
      */
 
     /**
+     * Carousel
+     *
      * @class Carousel
      * @classdesc An interactive Carousel component for navigating a list of generic items
      * @param {CarouselConfig} config The Carousel configuration
@@ -61,12 +95,14 @@
             // prevents multiple initialization
             config.element.removeAttribute("data-" + NS + "-is");
 
+            setupProperties(config.options);
             cacheElements(config.element);
             that._active = 0;
 
             if (that._elements.item) {
                 refreshActive();
                 bindEvents();
+                resetAutoInterval();
             }
 
             if (Granite && Granite.author && Granite.author.MessageChannel) {
@@ -115,32 +151,53 @@
         }
 
         /**
+         * Sets up properties for the Carousel based on the passed options.
+         *
+         * @private
+         * @param {Object} options The Carousel options
+         */
+        function setupProperties(options) {
+            that._properties = {};
+
+            for (var key in properties) {
+                if (properties.hasOwnProperty(key)) {
+                    var property = properties[key];
+                    var value = null;
+
+                    if (options && options[key] != null) {
+                        value = options[key];
+
+                        // transform the provided option
+                        if (property && typeof property.transform === "function") {
+                            value = property.transform(value);
+                        }
+                    }
+
+                    if (value === null) {
+                        // value still null, take the property default
+                        value = properties[key]["default"];
+                    }
+
+                    that._properties[key] = value;
+                }
+            }
+        }
+
+        /**
          * Binds Carousel event handling
          *
          * @private
          */
         function bindEvents() {
-            var prev = that._elements["prev"];
-            if (prev) {
-                prev.addEventListener("click", function() {
-                    if (that._active > 0) {
-                        that._active = that._active - 1;
-                    } else {
-                        that._active = that._elements["item"].length - 1;
-                    }
-                    refreshActive();
+            if (that._elements["previous"]) {
+                that._elements["previous"].addEventListener("click", function() {
+                    navigate(getPreviousIndex());
                 });
             }
 
-            var next = that._elements["next"];
-            if (next) {
-                next.addEventListener("click", function() {
-                    if (that._active < that._elements["item"].length - 1) {
-                        that._active = that._active + 1;
-                    } else {
-                        that._active = 0;
-                    }
-                    refreshActive();
+            if (that._elements["next"]) {
+                that._elements["next"].addEventListener("click", function() {
+                    navigate(getNextIndex());
                 });
             }
 
@@ -149,7 +206,7 @@
                 for (var i = 0; i < indicators.length; i++) {
                     (function(index) {
                         indicators[i].addEventListener("click", function(event) {
-                            navigate(index);
+                            navigateAndFocusIndicator(index);
                         });
                         indicators[i].addEventListener("keydown", function(event) {
                             onKeyDown(event);
@@ -157,6 +214,14 @@
                     })(i);
                 }
             }
+
+            that._elements.self.addEventListener("mouseenter", function() {
+                clearAutoInterval();
+            });
+
+            that._elements.self.addEventListener("mouseleave", function() {
+                resetAutoInterval();
+            });
         }
 
         /**
@@ -174,23 +239,23 @@
                 case keyCodes.ARROW_UP:
                     event.preventDefault();
                     if (index > 0) {
-                        navigate(index - 1);
+                        navigateAndFocusIndicator(index - 1);
                     }
                     break;
                 case keyCodes.ARROW_RIGHT:
                 case keyCodes.ARROW_DOWN:
                     event.preventDefault();
                     if (index < lastIndex) {
-                        navigate(index + 1);
+                        navigateAndFocusIndicator(index + 1);
                     }
                     break;
                 case keyCodes.HOME:
                     event.preventDefault();
-                    navigate(0);
+                    navigateAndFocusIndicator(0);
                     break;
                 case keyCodes.END:
                     event.preventDefault();
-                    navigate(lastIndex);
+                    navigateAndFocusIndicator(lastIndex);
                     break;
                 default:
                     return;
@@ -215,7 +280,6 @@
                             indicators[i].classList.add("cmp-carousel__indicator--active");
                             indicators[i].setAttribute("aria-selected", true);
                             indicators[i].setAttribute("tabindex", "0");
-                            focusWithoutScroll(indicators[i]);
                         } else {
                             items[i].classList.remove("cmp-carousel__item--active");
                             items[i].setAttribute("aria-hidden", true);
@@ -245,14 +309,83 @@
         }
 
         /**
+         * Retrieves the next active index, with looping
+         *
+         * @private
+         */
+        function getNextIndex() {
+            return that._active === (that._elements["item"].length - 1) ? 0 : that._active + 1;
+        }
+
+        /**
+         * Retrieves the previous active index, with looping
+         *
+         * @private
+         */
+        function getPreviousIndex() {
+            return that._active === 0 ? (that._elements["item"].length - 1) : that._active - 1;
+        }
+
+        /**
          * Navigates to the item at the provided index
          *
          * @private
          * @param {Number} index The index of the item to navigate to
          */
         function navigate(index) {
+            if (index < 0 || index > (that._elements["item"].length - 1)) {
+                return;
+            }
+
             that._active = index;
             refreshActive();
+
+            // reset the auto transition interval following navigation, if not already hovering the carousel
+            if (that._elements.self.parentElement.querySelector(":hover") !== that._elements.self) {
+                resetAutoInterval();
+            }
+        }
+
+        /**
+         * Navigates to the item at the provided index and ensures the active indicator gains focus
+         *
+         * @private
+         * @param {Number} index The index of the item to navigate to
+         */
+        function navigateAndFocusIndicator(index) {
+            navigate(index);
+            focusWithoutScroll(that._elements["indicator"][index]);
+        }
+
+        /**
+         * Starts/resets automatic slide transition interval
+         *
+         * @private
+         */
+        function resetAutoInterval() {
+            if (!that._properties.auto) {
+                return;
+            }
+            clearAutoInterval();
+            that._autoInterval = window.setInterval(function() {
+                var indicators = that._elements["indicators"];
+                if (indicators !== document.activeElement && indicators.contains(document.activeElement)) {
+                    // if an indicator has focus, ensure we switch focus following navigation
+                    navigateAndFocusIndicator(getNextIndex());
+                } else {
+                    navigate(getNextIndex());
+                }
+            }, that._properties.delay);
+        }
+
+        /**
+         * Clears/pauses automatic slide transition interval
+         *
+         * @private
+         */
+        function clearAutoInterval() {
+            window.clearInterval(that._autoInterval);
+            that._autoInterval = null;
         }
     }
 
@@ -261,6 +394,7 @@
      *
      * @private
      * @param {HTMLElement} element The Carousel element to read options data from
+     * @returns {Object} The options read from the component data attributes
      */
     function readData(element) {
         var data = element.dataset;

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -193,7 +193,6 @@
                             tabs[i].classList.add("cmp-tabs__tab--active");
                             tabs[i].setAttribute("aria-selected", true);
                             tabs[i].setAttribute("tabindex", "0");
-                            focusWithoutScroll(tabs[i]);
                         } else {
                             tabpanels[i].classList.remove("cmp-tabs__tabpanel--active");
                             tabpanels[i].setAttribute("aria-hidden", true);
@@ -231,6 +230,7 @@
         function navigate(index) {
             that._active = index;
             refreshActive();
+            focusWithoutScroll(that._elements["tab"][index]);
         }
     }
 

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -193,7 +193,7 @@
                             tabs[i].classList.add("cmp-tabs__tab--active");
                             tabs[i].setAttribute("aria-selected", true);
                             tabs[i].setAttribute("tabindex", "0");
-                            focusWithoutScroll(that._elements["tab"][index]);
+                            focusWithoutScroll(tabs[i]);
                         } else {
                             tabpanels[i].classList.remove("cmp-tabs__tabpanel--active");
                             tabpanels[i].setAttribute("aria-hidden", true);

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/tabs/v1/tabs/clientlibs/site/js/tabs.js
@@ -193,6 +193,7 @@
                             tabs[i].classList.add("cmp-tabs__tab--active");
                             tabs[i].setAttribute("aria-selected", true);
                             tabs[i].setAttribute("tabindex", "0");
+                            focusWithoutScroll(that._elements["tab"][index]);
                         } else {
                             tabpanels[i].classList.remove("cmp-tabs__tabpanel--active");
                             tabpanels[i].setAttribute("aria-hidden", true);
@@ -230,7 +231,6 @@
         function navigate(index) {
             that._active = index;
             refreshActive();
-            focusWithoutScroll(that._elements["tab"][index]);
         }
     }
 


### PR DESCRIPTION
- adds `autoplay` and `delay` Java api for Carousel
- adds dialog properties for `autoplay` / `delay` feature
- adds site widget logic for auto rotating carousel
- updates property JSDocs for all site widgets
- prev -> previous naming

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #315` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      | 👍
| Major: Breaking Change?  |
| Tests Added + Pass?      | 👍
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
