### PR TITLE
switch to the junit4 artifacts

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -395,7 +395,7 @@
         </dependency>
         <dependency>
             <groupId>io.wcm</groupId>
-            <artifactId>io.wcm.testing.aem-mock</artifactId>
+            <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.sling</groupId>
@@ -405,7 +405,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock</artifactId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
             <exclusions>
                 <!-- Exclude the older version of the API and use the one from the uber-jar -->
                 <exclusion>

--- a/extension/contentfragment/bundle/pom.xml
+++ b/extension/contentfragment/bundle/pom.xml
@@ -263,7 +263,7 @@
         </dependency>
         <dependency>
             <groupId>io.wcm</groupId>
-            <artifactId>io.wcm.testing.aem-mock</artifactId>
+            <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.sling</groupId>
@@ -273,7 +273,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
-            <artifactId>org.apache.sling.testing.sling-mock</artifactId>
+            <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
             <exclusions>
                 <!-- Exclude the older version of the API and use the one from the uber-jar -->
                 <exclusion>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -667,7 +667,7 @@
             </dependency>
             <dependency>
                 <groupId>io.wcm</groupId>
-                <artifactId>io.wcm.testing.aem-mock</artifactId>
+                <artifactId>io.wcm.testing.aem-mock.junit4</artifactId>
                 <version>2.3.0</version>
                 <scope>test</scope>
                 <exclusions>
@@ -679,7 +679,7 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.sling</groupId>
-                <artifactId>org.apache.sling.testing.sling-mock</artifactId>
+                <artifactId>org.apache.sling.testing.sling-mock.junit4</artifactId>
                 <version>2.3.2</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
eliminate some build warnings as some mocks now provide junit5 support.
