### PR TITLE
Image: Remove resourceType definition from dropTarget parameters 

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/wcm/components/image/v2/image/_cq_editConfig.xml
@@ -9,7 +9,6 @@
             propertyName="./fileReference">
             <parameters
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/image/v2/image"
                 imageCrop=""
                 imageMap=""
                 imageRotate=""/>


### PR DESCRIPTION
to avoid overwriting project-specific resource type with core component resource type when dropping asset.

This was already fixed in rev cd5a7f404335dc988759d82241dde2f97cfbf6cc for v1 of the image component, but accidentally introduced again with v2 of it.

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          | Yes
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | n/a
| Documentation Provided   | n/a
| Any Dependency Changes?  | no
| License                  | Apache License, Version 2.0
