### PR TITLE
[Carousel] Add accessibility features to navigate through the slides

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
@@ -23,7 +23,7 @@
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.path @ decorationTagName='div'}"
              role="tabpanel"
-             class="cmp-carousel__item"
+             class="cmp-carousel__item${itemList.first ? ' cmp-tabs__tabpanel--active' : ''}"
              data-cmp-hook-carousel="item"></div>
         <button role="button" class="cmp-carousel__action cmp-carousel__action--previous" data-cmp-hook-carousel="previous">
             <span class="cmp-carousel__action-icon"></span>
@@ -36,7 +36,7 @@
         <ol role="tablist" class="cmp-carousel__indicators" data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"
                 role="tab"
-                class="cmp-carousel__indicator"
+                class="cmp-carousel__indicator${itemList.first ? ' cmp-tabs__tabpanel--active' : ''}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>
         </ol>
     </div>

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/carousel.html
@@ -23,7 +23,7 @@
         <div data-sly-repeat.item="${carousel.items}"
              data-sly-resource="${item.path @ decorationTagName='div'}"
              role="tabpanel"
-             class="cmp-carousel__item${itemList.first ? ' cmp-tabs__tabpanel--active' : ''}"
+             class="cmp-carousel__item${itemList.first ? ' cmp-carousel__item--active' : ''}"
              data-cmp-hook-carousel="item"></div>
         <button role="button" class="cmp-carousel__action cmp-carousel__action--previous" data-cmp-hook-carousel="previous">
             <span class="cmp-carousel__action-icon"></span>
@@ -36,7 +36,7 @@
         <ol role="tablist" class="cmp-carousel__indicators" data-cmp-hook-carousel="indicators">
             <li data-sly-repeat.item="${carousel.items}"
                 role="tab"
-                class="cmp-carousel__indicator${itemList.first ? ' cmp-tabs__tabpanel--active' : ''}"
+                class="cmp-carousel__indicator${itemList.first ? ' cmp-carousel__indicator--active' : ''}"
                 data-cmp-hook-carousel="indicator">${item.title}</li>
         </ol>
     </div>

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -208,12 +208,13 @@
                         indicators[i].addEventListener("click", function(event) {
                             navigateAndFocusIndicator(index);
                         });
-                        indicators[i].addEventListener("keydown", function(event) {
-                            onKeyDown(event);
-                        });
                     })(i);
                 }
             }
+
+            that._elements.self.addEventListener("keydown", function(event) {
+                onKeyDown(event);
+            });
 
             that._elements.self.addEventListener("mouseenter", function() {
                 clearAutoplayInterval();

--- a/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
+++ b/content/src/content/jcr_root/apps/core/wcm/sandbox/components/carousel/v1/carousel/clientlibs/site/js/carousel.js
@@ -212,17 +212,9 @@
                 }
             }
 
-            that._elements.self.addEventListener("keydown", function(event) {
-                onKeyDown(event);
-            });
-
-            that._elements.self.addEventListener("mouseenter", function() {
-                clearAutoplayInterval();
-            });
-
-            that._elements.self.addEventListener("mouseleave", function() {
-                resetAutoplayInterval();
-            });
+            that._elements.self.addEventListener("keydown", onKeyDown);
+            that._elements.self.addEventListener("mouseenter", onMouseEnter);
+            that._elements.self.addEventListener("mouseleave", onMouseLeave);
         }
 
         /**
@@ -261,6 +253,26 @@
                 default:
                     return;
             }
+        }
+
+        /**
+         * Handles carousel mouseenter events
+         *
+         * @private
+         * @param {Object} event The mouseenter event
+         */
+        function onMouseEnter(event) {
+            clearAutoplayInterval();
+        }
+
+        /**
+         * Handles carousel mouseleave events
+         *
+         * @private
+         * @param {Object} event The mouseleave event
+         */
+        function onMouseLeave(event) {
+            resetAutoplayInterval();
         }
 
         /**


### PR DESCRIPTION
Review feedback:
- binds keyboard navigation to carousel rather than indicators
- ensures first item and indicator are active in the carousel markup (prevents FOUC)

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #309` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | 👍
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | NA
| Documentation Provided   | NA (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
