### PR TITLE
[Tabs][Carousel] Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ The latest version of the Core Components, require the below minimum system requ
 
 Core Components | Extension | AEM 6.4 | AEM 6.3 | Java
 ----------------|-----------|---------|---------|------
-[2.1.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.1.0) | 1.0.6 | 6.4.2.0 | 6.3.3.0 | 1.8
-
+[2.2.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.2.0) | 1.0.6 | 6.4.2.0 | 6.3.3.0 | 1.8
 
 For a list of requirements for previous versions, see [Historical System Requirements](VERSIONS.md).
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,10 +4,11 @@ See below for a full list of minimum system requirements for historical versions
 
 Core Components | Extension | AEM 6.4 | AEM 6.3 | Java
 ----------------|-----------|---------|---------|------
-[2.1.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.1.0)           | 1.0.6 | 6.4.2.0 | 6.3.3.0 | 1.8
-[2.0.6](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.6), [2.0.8](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.8)           | 1.0.2, 1.0.4 | 6.4.0.0 | 6.3.2.0 | 1.8
-[2.0.4](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.4)           | 1.0.0 | 6.4.0.0 | 6.3.2.0 | 1.8
-[2.0.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.0)           | sandbox/preview | 6.4.0.0 | 6.3.2.0 | 1.8
-[1.1.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.1.0)           | sandbox/preview | 6.4.0.0 | 6.3.1.0 | 1.8
-[1.0.4](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.4), [1.0.6](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.6)    | - | 6.4.0.0 | 6.3.0.0 | 1.8
-[1.0.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.0), [1.0.2](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.all-1.0.2)    | - | 6.4.0.0 | 6.3.0.0 | 1.7
+[2.2.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.2.0) | 1.0.6 | 6.4.2.0 | 6.3.3.0 | 1.8
+[2.1.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.1.0) | 1.0.6 | 6.4.2.0 | 6.3.3.0 | 1.8
+[2.0.6](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.6), [2.0.8](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.8) | 1.0.2, 1.0.4 | 6.4.0.0 | 6.3.2.0 | 1.8
+[2.0.4](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.4) | 1.0.0 | 6.4.0.0 | 6.3.2.0 | 1.8
+[2.0.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-2.0.0) | sandbox/preview | 6.4.0.0 | 6.3.2.0 | 1.8
+[1.1.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.1.0) | sandbox/preview | 6.4.0.0 | 6.3.1.0 | 1.8
+[1.0.4](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.4), [1.0.6](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.6) | - | 6.4.0.0 | 6.3.0.0 | 1.8
+[1.0.0](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.reactor-1.0.0), [1.0.2](https://github.com/Adobe-Marketing-Cloud/aem-core-wcm-components/releases/tag/core.wcm.components.all-1.0.2) | - | 6.4.0.0 | 6.3.0.0 | 1.7

--- a/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/carousel/v1/carousel/README.md
@@ -106,5 +106,5 @@ that the UI component is updated when the active item is switched in the editor 
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.3
-* **Status**: preview
-
+* **Status**: production-ready
+* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_carousel\_v1](https://www.adobe.com/go/aem_cmp_carousel_v1)

--- a/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs/README.md
@@ -87,5 +87,5 @@ that the UI component is updated when the active item is switched in the editor 
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.3
-* **Status**: preview
-
+* **Status**: production-ready
+* **Documentation**: [https://www.adobe.com/go/aem\_cmp\_tabs\_v1](https://www.adobe.com/go/aem_cmp_tabs_v1)

--- a/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/README.md
+++ b/content/src/content/jcr_root/apps/core/wcm/components/teaser/v1/teaser/README.md
@@ -81,5 +81,5 @@ BLOCK cmp-teaser
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.3
-* **Status**: preview
+* **Status**: production-ready
 * **Documentation**: [https://www.adobe.com/go/aem\_cmp\_teaser\_v1](https://www.adobe.com/go/aem_cmp_teaser_v1)


### PR DESCRIPTION
- marks tabs, carousel production ready
- adds 2.2.0 release to system requirements
