### PR TITLE
[PanelContainer] JS console error in preview mode

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/contentTree.js
+++ b/content/src/content/jcr_root/apps/core/wcm/components/commons/editor/clientlibs/panelcontainer/v1/js/contentTree.js
@@ -135,7 +135,9 @@
         var items = CQ.CoreComponents.panelcontainer.v1.utils.getPanelContainerItems(editable);
 
         for (var i = 0; i < items.length; i++) {
-            items[i].overlay.setDisabled((activeIndex !== i));
+            if (items[i].overlay) {
+                items[i].overlay.setDisabled((activeIndex !== i));
+            }
         }
     }
 


### PR DESCRIPTION
ensures `overlay` object is available before disabling it